### PR TITLE
Added support for using authenticated redis server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ install:
 - pip install coverage coveralls Mako
 before_script:
 - redis-server --port 6399 &
+- redis-server --port 6400 &
+- redis-cli -p 6400 config set requirepass foobared
 script: py.test --cov flask_bitmapist --cov-report term-missing --pep8 --flakes
 after_success:
 - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ install:
 before_script:
 - redis-server --port 6399 &
 - redis-server --port 6400 &
+script:
 - redis-cli -p 6400 config set requirepass foobared
-script: py.test --cov flask_bitmapist --cov-report term-missing --pep8 --flakes
+- py.test --cov flask_bitmapist --cov-report term-missing --pep8 --flakes
 after_success:
 - coveralls
 notifications:

--- a/flask_bitmapist/core.py
+++ b/flask_bitmapist/core.py
@@ -37,7 +37,8 @@ class FlaskBitmapist(object):
     def init_app(self, app, config=None):
         "This is used to initialize bitmapist with your app object"
         self.app = app
-        self.redis_url = app.config.get('BITMAPIST_REDIS_URL', 'redis://localhost:6379')
+        self.redis_url = app.config.get('BITMAPIST_REDIS_URL',
+                                        'redis://localhost:6379')
         self.redis_auth = app.config.get('BITMAPIST_REDIS_PASSWORD')
 
         if self.redis_url not in _bitmapist.SYSTEMS.values():
@@ -46,10 +47,10 @@ class FlaskBitmapist(object):
                 app.config.get('BITMAPIST_REDIS_SYSTEM', 'default'),
                 host,
                 port,
-                password = self.redis_auth)
+                password=self.redis_auth)
 
-
-        _bitmapist.TRACK_HOURLY = app.config.get('BITMAPIST_TRACK_HOURLY', False)
+        _bitmapist.TRACK_HOURLY = app.config.get('BITMAPIST_TRACK_HOURLY',
+                                                 False)
 
         if not hasattr(app, 'extensions'):
             app.extensions = {}

--- a/flask_bitmapist/core.py
+++ b/flask_bitmapist/core.py
@@ -21,6 +21,7 @@ class FlaskBitmapist(object):
 
     app = None
     redis_url = None
+    redis_auth = None
     SYSTEMS = _bitmapist.SYSTEMS
     TRACK_HOURLY = _bitmapist.TRACK_HOURLY
 
@@ -37,13 +38,16 @@ class FlaskBitmapist(object):
         "This is used to initialize bitmapist with your app object"
         self.app = app
         self.redis_url = app.config.get('BITMAPIST_REDIS_URL', 'redis://localhost:6379')
+        self.redis_auth = app.config.get('BITMAPIST_REDIS_PASSWORD')
 
         if self.redis_url not in _bitmapist.SYSTEMS.values():
             host, port = _get_redis_connection(self.redis_url)
             _bitmapist.setup_redis(
                 app.config.get('BITMAPIST_REDIS_SYSTEM', 'default'),
                 host,
-                port)
+                port,
+                password = self.redis_auth)
+
 
         _bitmapist.TRACK_HOURLY = app.config.get('BITMAPIST_TRACK_HOURLY', False)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ def app(request):
     app = Flask(__name__)
     app.debug = True
     app.config['TESTING'] = True
-    # app.config['BITMAPIST_REDIS_URL'] = 'redis://localhost:6379'
     app.config['BITMAPIST_REDIS_URL'] = 'redis://localhost:6399'
     app.config['SECRET_KEY'] = 'secret'
     app.config['SECRET_KEY'] = 'verysecret'
@@ -131,3 +130,14 @@ def sqlalchemy(app, request, sqlalchemy_db, sqlalchemy_user):
     request.addfinalizer(teardown)
     # TODO: may return just db with tests using sqlalchemy_user fixture directly
     return db, sqlalchemy_user
+
+
+@pytest.fixture
+def auth_bitmap():
+    app = Flask(__name__)
+    app.config['BITMAPIST_REDIS_URL'] = 'redis://localhost:6400'
+    app.config['BITMAPIST_REDIS_PASSWORD'] = 'foobared'
+    app.config['SECRET_KEY'] = 'secret'
+    app.config['SECRET_KEY'] = 'verysecret'
+    auth_bitmap = FlaskBitmapist(app)
+    return auth_bitmap

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
 import mock
 from random import randint
 
@@ -243,14 +244,10 @@ def test_get_cohort_structure(mock_week_events, mock_month_events,
         assert _week(d) == _week(now - timedelta(weeks=3-idx))
     # 2 - months
     for idx, d in enumerate(d2):
-        this_month = now.replace(day=1)  # work with first day of month
-        months_ago = (5 - idx) * 365 / 12  # no 'months' arg for timedelta
-        assert _month(d) == _month(this_month - timedelta(months_ago))
+        assert _month(d) == _month(now - relativedelta(months=(5 - idx)))
     # 3 - years
     for idx, d in enumerate(d3):
-        this_year = now.replace(month=1, day=1)  # work with first day of year
-        years_ago = (1 - idx) * 365  # no 'years' arg for timedelta
-        assert _year(d) == _year(this_year - timedelta(years_ago))
+        assert _year(d) == _year(now - relativedelta(years=(1-idx)))
 
 
 def test_chain_events():

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -629,3 +629,16 @@ def test_unmark_function(app, client):
 
     unmark_event('active', 126)
     assert 126 not in MonthEvents('active', now.year, now.month)
+
+
+def test_authenticated_redis(app, auth_bitmap):
+    assert auth_bitmap.redis_auth == 'foobared'
+
+    # Test to make sure auth_bitmap setup with different set of params
+    assert auth_bitmap.redis_url != app.config['BITMAPIST_REDIS_URL']
+
+    mark_event('active', 42)
+    assert 42 in MonthEvents('active', now.year, now.month)
+
+    unmark_event('active', 42)
+    assert 42 not in MonthEvents('active', now.year, now.month)


### PR DESCRIPTION
Used the BITMAPIST_REDIS_PASSWORD to provide support for an authenticated redis instance in the app config variables. 